### PR TITLE
Add support for Stoplight Visualisation

### DIFF
--- a/Example/Sources/App/Controllers/OpenAPIController.swift
+++ b/Example/Sources/App/Controllers/OpenAPIController.swift
@@ -6,30 +6,32 @@ struct OpenAPIController: RouteCollection {
 
 	// MARK: Internal
 
-	func boot(routes: RoutesBuilder) throws {
-
-		// generate OpenAPI documentation
-		routes.get("swagger", "swagger.json") { req in
-			req.application.routes.openAPI(
-				info: InfoObject(
-					title: "Swagger Petstore - OpenAPI 3.0",
-					description: "This is a sample Pet Store Server based on the OpenAPI 3.0.1 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
-					termsOfService: URL(string: "http://swagger.io/terms/"),
-					contact: ContactObject(
-						email: "apiteam@swagger.io"
-					),
-					license: LicenseObject(
-						name: "Apache 2.0",
-						url: URL(string: "http://www.apache.org/licenses/LICENSE-2.0.html")
-					),
-					version: Version(1, 0, 17)
-				),
-				externalDocs: ExternalDocumentationObject(
-					description: "Find out more about Swagger",
-					url: URL(string: "http://swagger.io")!
-				)
-			)
-		}
-		.excludeFromOpenAPI()
-	}
+    func boot(routes: RoutesBuilder) throws {
+        
+        // generate OpenAPI documentation
+        routes.get("swagger", "swagger.json") { req in
+            req.application.routes.openAPI(
+                info: InfoObject(
+                    title: "Swagger Petstore - OpenAPI 3.0",
+                    description: "This is a sample Pet Store Server based on the OpenAPI 3.0.1 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+                    termsOfService: URL(string: "http://swagger.io/terms/"),
+                    contact: ContactObject(
+                        email: "apiteam@swagger.io"
+                    ),
+                    license: LicenseObject(
+                        name: "Apache 2.0",
+                        url: URL(string: "http://www.apache.org/licenses/LICENSE-2.0.html")
+                    ),
+                    version: Version(1, 0, 17)
+                ),
+                externalDocs: ExternalDocumentationObject(
+                    description: "Find out more about Swagger",
+                    url: URL(string: "http://swagger.io")!
+                )
+            )
+        }
+        .excludeFromOpenAPI()
+        
+        routes.grouped("docs").registerOpenAPIElements(path: "/swagger/swagger.json")
+    }
 }

--- a/Sources/VaporToOpenAPI/Elements.swift
+++ b/Sources/VaporToOpenAPI/Elements.swift
@@ -1,0 +1,35 @@
+import Vapor
+
+extension RoutesBuilder {
+    public func registerOpenAPIElements(path: String, title: String = "OpenAPI Documentation") {
+        get("") { req in
+            var headers = HTTPHeaders()
+            headers.contentType = .html
+            
+            return Response(
+                status: .ok,
+                headers: headers,
+                body: .init(string: """
+                <!doctype html>
+                <html lang="en">
+
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+                  <title>\(title)</title>
+
+                  <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+                  <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+                </head>
+
+                <body>
+                  <elements-api apiDescriptionUrl="\(path)" router="hash" />
+                </body>
+
+                </html>
+                """)
+            )
+        }
+        .excludeFromOpenAPI()
+    }
+}


### PR DESCRIPTION
Closes #23

Path is configurable (required), as is the title (optional).
One line of code, and no dependencies, to add this to an existing project. (Example had some indentation issues which Xcode fixed for you).

This is an example of what it looks like if you head to `localhost:8080/docs`

<img width="1728" alt="Screenshot 2024-05-04 at 12 04 19 PM" src="https://github.com/dankinsoid/VaporToOpenAPI/assets/15193942/dbf578b1-b711-4076-ab9a-7c4f61d549ee">
